### PR TITLE
Update nrc-netlink.c

### DIFF
--- a/package/src/nrc/nrc-netlink.c
+++ b/package/src/nrc/nrc-netlink.c
@@ -31,10 +31,10 @@ static struct nrc *nrc_nw;
 
 
 #ifdef CONFIG_SUPPORT_NEW_NETLINK
-static int nrc_nl_pre_doit(const struct genl_ops *ops,
+static int nrc_nl_pre_doit(const struct genl_split_ops *ops,
 			   struct sk_buff *skb, struct genl_info *info)
 #else
-static int nrc_nl_pre_doit(struct genl_ops *ops,
+static int nrc_nl_pre_doit(struct genl_split_ops *ops,
 			   struct sk_buff *skb, struct genl_info *info)
 #endif
 {
@@ -42,10 +42,10 @@ static int nrc_nl_pre_doit(struct genl_ops *ops,
 }
 
 #ifdef CONFIG_SUPPORT_NEW_NETLINK
-static void nrc_nl_post_doit(const struct genl_ops *ops,
+static void nrc_nl_post_doit(const struct genl_split_ops *ops,
 			     struct sk_buff *skb, struct genl_info *info)
 #else
-static void nrc_nl_post_doit(struct genl_ops *ops,
+static void nrc_nl_post_doit(struct genl_split_ops *ops,
 			     struct sk_buff *skb, struct genl_info *info)
 #endif
 {


### PR DESCRIPTION
Replace `genl_ops` with `genl_split_ops`.

This is to fix following compilation error on kernel __6.6.20___ on latest Raspberry Pi OS Lite for RPi4B:
```
cbugk@rpi-ah:~/nrc7394_sw_pkg/package/src/nrc $ make

make[1]: Entering directory '/usr/src/linux-headers-6.6.20+rpt-rpi-v8'
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-mac80211.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-trx.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-init.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-debug.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/hif.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/wim.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-fw.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-netlink.o
/home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-netlink.c:129:27: error: initialization of ‘int (*)(const struct genl_split_ops *, struct sk_buff *, struct genl_info *)’ from incompatible pointer type ‘int (*)(const struct genl_ops *, struct sk_buff *, struct genl_info *)’ [-Werror=incompatible-pointer-types]
  129 |         .pre_doit       = nrc_nl_pre_doit,
      |                           ^~~~~~~~~~~~~~~
/home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-netlink.c:129:27: note: (near initialization for ‘nrc_nl_fam.pre_doit’)
/home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-netlink.c:130:27: error: initialization of ‘void (*)(const struct genl_split_ops *, struct sk_buff *, struct genl_info *)’ from incompatible pointer type ‘void (*)(const struct genl_ops *, struct sk_buff *, struct genl_info *)’ [-Werror=incompatible-pointer-types]
  130 |         .post_doit      = nrc_nl_post_doit,
      |                           ^~~~~~~~~~~~~~~~
/home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-netlink.c:130:27: note: (near initialization for ‘nrc_nl_fam.post_doit’)
cc1: all warnings being treated as errors
make[3]: *** [/usr/src/linux-headers-6.6.20+rpt-common-rpi/scripts/Makefile.build:248: /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-netlink.o] Error 1
make[2]: *** [/usr/src/linux-headers-6.6.20+rpt-common-rpi/Makefile:1938: /home/cbugk/nrc7394_sw_pkg/package/src/nrc] Error 2
make[1]: *** [/usr/src/linux-headers-6.6.20+rpt-common-rpi/Makefile:246: __sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-6.6.20+rpt-rpi-v8'
make: *** [Makefile:50: modules] Error 2
```

After the change:
```
cbugk@rpi-ah:~/nrc7394_sw_pkg/package/src/nrc $ make clean; make

make[1]: Entering directory '/usr/src/linux-headers-6.6.20+rpt-rpi-v8'
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-mac80211.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-trx.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-init.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-debug.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/hif.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/wim.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-fw.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-netlink.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-hif-cspi.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/mac80211-ext.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-stats.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-pm.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-dump.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-bd.o
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc-s1g.o
  LD [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc.o
  MODPOST /home/cbugk/nrc7394_sw_pkg/package/src/nrc/Module.symvers
  CC [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc.mod.o
  LD [M]  /home/cbugk/nrc7394_sw_pkg/package/src/nrc/nrc.ko
make[1]: Leaving directory '/usr/src/linux-headers-6.6.20+rpt-rpi-v8'
```