### PR TITLE
Fix build on Ubuntu 6.8.x kernels

### DIFF
--- a/package/src/nrc/nrc-bd.h
+++ b/package/src/nrc/nrc-bd.h
@@ -53,6 +53,4 @@ extern bool g_bd_valid;
 struct wim_bd_param * nrc_read_bd_tx_pwr(struct nrc *nw, uint8_t *cc);
 int nrc_check_bd(struct nrc *nw);
 #endif /* defined(CONFIG_SUPPORT_BD) */
-uint16_t nrc_get_non_s1g_freq(uint8_t cc_index, uint8_t s1g_ch_index);
-bool nrc_set_supp_ch_list(struct wim_bd_param *bd);
 #endif //_NRC_BD_H_

--- a/package/src/nrc/nrc-fw.h
+++ b/package/src/nrc/nrc-fw.h
@@ -62,5 +62,4 @@ bool nrc_check_fw_ready(struct nrc *nw);
 void nrc_set_boot_ready(struct nrc *nw);
 void nrc_download_fw(struct nrc *nw);
 void nrc_release_fw(struct nrc *nw);
-void nrc_fw_update_frag(struct nrc_fw_priv *priv, struct fw_frag *frag);
 #endif

--- a/package/src/nrc/nrc-hif.h
+++ b/package/src/nrc/nrc-hif.h
@@ -438,9 +438,6 @@ void nrc_hif_sleep_target_prepare (struct nrc_hif_device *dev, int mode);
 void nrc_hif_sleep_target_start (struct nrc_hif_device *dev, int mode);
 void nrc_hif_sleep_target_end (struct nrc_hif_device *dev, int mode);
 
-bool nrc_is_valid_vif (struct nrc *nw, struct ieee80211_vif *vif);
-bool ieee80211_is_data_data(__le16 fc);
-void insert_qos_ctrl_field_in_skb(struct sk_buff *skb, unsigned int hdr_len);
 #define MON_STA_LIST_NUM 32
 
 typedef struct _mon_sta_t{
@@ -452,11 +449,6 @@ typedef struct _mon_sta_t{
 	uint32_t last_ts;
 } MON_STA_T;
 
-MON_STA_T* nrc_ampdu_mon_find_sta(uint8_t* addr);
-MON_STA_T* nrc_ampdu_mon_add_sta(uint8_t* addr);
-uint32_t nrc_ampdu_mon_get_ref_id(struct nrc *nw, struct sk_buff *skb);
 bool is_tcp_ack(struct sk_buff *skb);
-bool is_mgmt(struct sk_buff *skb);
-bool is_urgent_frame(struct sk_buff *skb);
-int nrc_xmit_wim(struct nrc *nw, struct sk_buff *skb, enum HIF_SUBTYPE stype);
+
 #endif

--- a/package/src/nrc/nrc-init.h
+++ b/package/src/nrc/nrc-init.h
@@ -39,5 +39,4 @@ int nrc_nw_stop (struct nrc *nw, bool restart);
 void nrc_nw_restart (struct nrc *nw);
 int nrc_nw_set_model_conf (struct nrc *nw, u16 chip_id);
 int country_match(const char *const cc[], const char *const country);
-int nrc_fw_start(struct nrc *nw);
 #endif

--- a/package/src/nrc/nrc-mac80211.h
+++ b/package/src/nrc/nrc-mac80211.h
@@ -160,13 +160,4 @@ void nrc_cleanup_ba_session_all (struct nrc *nw);
 
 int nrc_mac_restart (struct nrc *nw);
 
-unsigned int nrc_ac_credit(struct nrc *nw, int ac);
-const char *iftype_string(enum nl80211_iftype iftype);
-void scan_complete(struct ieee80211_hw *hw, bool aborted);
-void nrc_mac_set_wakeup(struct ieee80211_hw *hw, bool enabled);
-int nrc_mac_resume(struct ieee80211_hw *hw);
-int nrc_mac_suspend(struct ieee80211_hw *hw, struct cfg80211_wowlan *wowlan);
-void remotecmd_callback(struct timer_list *t);
-void remotecmd_schedule_off(struct wiphy *wiphy, struct wireless_dev *wdev,
-				u8 subcmd, const u8 cntdwn, u16 beacon_int);
 #endif

--- a/package/src/nrc/nrc-ps.h
+++ b/package/src/nrc/nrc-ps.h
@@ -20,6 +20,5 @@
 #include "nrc.h"
 
 int nrc_ps_set_mode (struct nrc *nw, enum NRC_PS_MODE mode, int timeout);
-char *nrc_ps_mode_str (enum NRC_PS_MODE mode);
 
 #endif

--- a/package/src/nrc/wim.h
+++ b/package/src/nrc/wim.h
@@ -200,13 +200,5 @@ int nrc_wim_rx(struct nrc *nw, struct sk_buff *skb, u8 subtype);
 int nrc_wim_pm_req(struct nrc *nw, uint32_t cmd, uint64_t arg);
 
 int nrc_wim_set_ps (struct nrc *nw, enum NRC_PS_MODE mode, int timeout);
-
-void nrc_wim_set_twt_responder (struct nrc *nw, struct sk_buff *skb, u8 enable);
-void nrc_wim_set_twt_requester (struct nrc *nw, struct sk_buff *skb, u8 enable);
 void nrc_wim_set_twt_grouping (struct nrc *nw, struct sk_buff *skb, u8 enable);
-void nrc_wim_set_rc_mode (struct nrc *nw, struct sk_buff *skb, u8 mode);
-void nrc_wim_set_default_mcs (struct nrc *nw, struct sk_buff *skb, u8 mcs);
-void nrc_wim_handle_fw_ready(struct nrc *nw);
-void nrc_wim_handle_fw_reload(struct nrc *nw);
-void nrc_wim_handle_req_deauth(struct nrc *nw);
 #endif


### PR DESCRIPTION
Fixes broken compilation with Ubuntu 6.8.x headers (Ubuntu Noble).

- Remove stale includes
- Adjust API calls for 6.8 changes

Signed-off-by: teledatics <james@teledatics.com>